### PR TITLE
(mintty) keep home environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+
+## wsltty-patch
+
+wsltty personal patched version
+
+- (mintty) keep home environment variable (#1)
+
+
+
+## wsltty
+
 Mintty as a terminal for WSL (Windows Subsystem for Linux).
 
 <img align=right src=wsltty.png>

--- a/makefile
+++ b/makefile
@@ -179,6 +179,7 @@ wslbridge-backend:	wslbridge-source
 mintty-get:
 	$(wgeto) https://github.com/mintty/mintty/archive/$(minttyver).zip -o mintty-$(minttyver).zip
 	unzip -o mintty-$(minttyver).zip
+	cd mintty-$(minttyver) && cat ../patch/mintty/*.patch | patch -p1
 	cp mintty-$(minttyver)/icon/terminal.ico mintty.ico
 
 wslbuild=LDFLAGS="-static -static-libgcc -s"

--- a/patch/mintty/0001-keep-home-env-var.patch
+++ b/patch/mintty/0001-keep-home-env-var.patch
@@ -1,0 +1,19 @@
+--- mintty-3.6.1.orig/src/winmain.c	2022-04-24 23:35:43.000000000 +0900
++++ mintty-3.6.1/src/winmain.c	2023-01-22 23:54:31.123184900 +0900
+@@ -6179,9 +6179,13 @@
+       printf("<%s>\n", *new_argv++);
+ #endif
+ 
+-    // prevent HOME from being propagated back to Windows applications 
+-    // if called from WSL (mintty/wsltty#76)
+-    unsetenv("HOME");
++    // HOME env variable is drop when invoking windows exe from WSL · Issue #324 · mintty/wsltty
++    // https://github.com/mintty/wsltty/issues/324
++    // ----
++    // // prevent HOME from being propagated back to Windows applications 
++    // // if called from WSL (mintty/wsltty#76)
++    // unsetenv("HOME");
++    // ----
+   }
+   else if (*argv && (argv[1] || strcmp(*argv, "-")))  // argv is a command
+     cmd = *argv;


### PR DESCRIPTION
Fix to keep HOME environment variable.

described: HOME env variable is drop when invoking windows exe from WSL · Issue #324 · mintty/wsltty
https://github.com/mintty/wsltty/issues/324

